### PR TITLE
Reduce memory footprint of n-grams frequencies generation

### DIFF
--- a/licence.txt
+++ b/licence.txt
@@ -1,0 +1,22 @@
+Tatoeba Project, free collaborative creation of multilingual corpuses project
+Copyright (C) 2012 Allan SIMON <allan.simon@supinfo.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+@category Tatodetect
+@package  Tools
+@author   Allan SIMON <allan.simon@supinfo.com>
+@license  Affero General Public License
+@link     http://tatoeba.org

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -26,34 +26,31 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-# languages that don't use an alphabet
-# we put them apart as they are likely to have a lot of different
-# ngrams and by so need to have a lower limit for the ngrams we kept
-# for that languages
+# some languages that don't use an alphabet are put apart as they are likely
+# to have a lot of different ngrams and by so need to have a lower limit for
+# the ngrams we kept for that languages
 IDEOGRAM_LANGS = ("wuu", "yue", "cmn")
 IDEOGRAM_NGRAM_FREQ_LIMIT = 0.000005
 NGRAM_FREQ_LIMIT = 0.00001
-# number of 1-gram a user must have submitted in one language to
-# be considered as possibly contributing in that languages
-# note that this number is currently purely arbitrary
+# minimum number of characters a user must have submitted in one language to
+# be considered as a key contributor in this language (note that this number
+# is currently purely arbitrary)
 MIN_USER_CONTRIB_IN_LANG = 100
-# we will generate the ngram from 2-gram to X-grams
+# minimum and maximum sizes of the n-grams to be generated
 MIN_NGRAM_SIZE = 2
 MAX_NGRAM_SIZE = 5
-# some names of the table in the database
-TABLE_NGRAM = "grams"
-TABLE_STAT = "langstat"
-TABLE_USR_STAT = "users_langs"
 
 
-class NgramCounterDB:
-    """A sqlite database for tracking:
+class RawTatodetectDB:
+    """A sqlite database for tracking all n-grams counts and user
+    contributions in the Tatoeba corpus
 
-    The occurrence counts of every n-gram found in the
-    Tatoeba corpus
+    It handles:
+    -   the occurrence counts of every n-gram found in the
+        Tatoeba corpus
 
-    Statistics related to user contributions to Tatoeba
-    in various languages
+    -   the contribution scores of the Tatoeba users in every
+        language they have contributed to
     """
 
     def __init__(self, db_path: Path) -> None:
@@ -65,18 +62,16 @@ class NgramCounterDB:
         """
         self._fp = db_path
 
-        self._conn = self._init_db()
-
-    def count_ngram_hits(
+    def count(
         self,
         sentences_detailed_path: Path,
         sentence_blacklist: list,
         buffer_length: int = 5000000,
     ) -> None:
-        """Count n-grams' occurrences for each Tatoeba language
+        """Count n-grams' occurrences for every Tatoeba language
 
         A contribution score equal to sum(len(sentences))
-        is also computed for every language a user contributed to.
+        is also computed for every language a user has contributed to.
 
         All results are gradually saved into database tables in
         order to mitigate the memory footprint of the process.
@@ -90,23 +85,24 @@ class NgramCounterDB:
             into account for this counting
         buffer_length : int, optional
             the maximum number of n-grams for which counts are kept in RAM,
-            by default 5000000
-            Note thet process speed mainly depends on the amount of data
+            by default 5,000,000.
+            Note that process speed mainly depends on the amount of data
             written to disk and consequently increases with the buffer size.
         """
-        # delete older database found at this path
+        # the former database is overwritten
         if self._fp.exists():
-            print(f"Warning, the older n-gram counter data will be overwritten")
+            print(f"Deleting former {self._fp.name} database")
             self._fp.unlink()
-            self._init_db()
+        # initialize tables
+        self._init_db()
 
         user_lang_score = defaultdict(int)
-        for n in range(MAX_NGRAM_SIZE, 1, -1):
-            table_name = f"{TABLE_NGRAM}{n}"
+        for n in range(MAX_NGRAM_SIZE, MIN_NGRAM_SIZE - 1, -1):
+            table_name = f"grams{n}"
             lang_ngram_cnt = defaultdict(lambda: defaultdict(int))
             with open(sentences_detailed_path, "r", encoding="utf-8") as f:
                 for line_id, line in enumerate(f):
-                    self._print_status(line_id, gram_length=n)
+                    self._print_status(line_id, ngram_size=n)
                     try:
                         fields = line.rstrip().split("\t")
                         sent_id, lang, text, user = fields[:4]
@@ -114,15 +110,14 @@ class NgramCounterDB:
                         print(f"Skipped erroneous line {line_id}: {line}")
                         continue
 
-                    # we ignore the sentence with an unset language
+                    # sentences with an unset language are ignored
                     if lang == "\\N" or lang == "":
                         continue
-
-                    # we ignore the sentence with wrong flag
+                    # sentences with an id matching the blacklist are ignored
                     if int(sent_id) in sentence_blacklist:
                         continue
 
-                    # update user contribution score during last reader loop
+                    # compute user contribution score during last file reading
                     if n == MIN_NGRAM_SIZE:
                         user_lang_score[(user, lang)] += len(text)
 
@@ -131,179 +126,209 @@ class NgramCounterDB:
                         ngram = text[i : i + n]
                         lang_ngram_cnt[lang][ngram] += 1
 
-                    # if buffer is full save it into table and then empty it
+                    # when buffer is full, save it into table and empty it
                     tot_ngrams = sum(len(v) for v in lang_ngram_cnt.values())
                     if tot_ngrams >= buffer_length:
                         for lang, ngram_hits in lang_ngram_cnt.items():
-                            self._upsert_hits(ngram_hits, lang, table_name)
+                            self._upsert_ngram_hits(
+                                ngram_hits, lang, table_name
+                            )
                         lang_ngram_cnt = defaultdict(lambda: defaultdict(int))
 
-            # move ngram hits from memory to table
-            for lang, ngram_hits in lang_ngram_cnt.items():
-                self._upsert_hits(ngram_hits, lang, table_name)
+            self._print_status(line_id, ngram_size=n, force=True)
 
-            self._print_status(line_id, gram_length=n, force=True)
+            # move remaining ngram hits from memory to database tables
+            for lang, ngram_hits in lang_ngram_cnt.items():
+                self._upsert_ngram_hits(ngram_hits, lang, table_name)
+
             print(" done")
 
-    def _init_db(self):
+        # save users contribution scores
+        self._insert_user_scores(user_lang_score)
 
-        conn = sqlite3.connect(self._fp)
-        with conn:
+    def _init_db(self) -> None:
+        """Open the database connection and initialize the tables"""
+
+        with sqlite3.connect(self._fp) as conn:
+            # create a table for each n-gram type
+            for n in range(MIN_NGRAM_SIZE, MAX_NGRAM_SIZE + 1):
+                conn.execute(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS grams{n} (
+                      'gram' text not null,
+                      'lang'text not null,
+                      'hit'  int not null,
+                    PRIMARY KEY("gram","lang")
+                    );
+                    """
+                )
+            # create a table dedicated to users contribution scores
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS users_langs (
+                  'user' text not null,
+                  'lang' text not null,
+                  'total' int not null default 0
+                );
+                """
+            )
+
+    def _upsert_ngram_hits(
+        self, ngram_hits: dict, lang: str, table_name: str
+    ) -> None:
+        """Update n-gram hit count values in this table"""
+
+        with sqlite3.connect(self._fp) as conn:
             # some optimization to make connection faster
             conn.execute("PRAGMA journal_mode=MEMORY;")
             conn.execute("PRAGMA temp_store=MEMORY;")
 
-        with conn:
-            # create a table for each n-gram type counts
-            for n in range(MIN_NGRAM_SIZE, MAX_NGRAM_SIZE + 1):
-                conn.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS %s (
-                    'gram' text not null,
-                    'lang'text not null,
-                    'hit'  int not null,
-                    PRIMARY KEY("gram","lang")
-                    );
-                    """
-                    % (TABLE_NGRAM + str(n))
-                )
-            # create a table for storing the sentences counts of users
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS %s (
-                    'user' text not null,
-                    'lang' text not null ,
-                    'total' int not null default 0
-                );
-                """
-                % (TABLE_USR_STAT)
-            )
-
-        return conn
-
-    def _upsert_hits(self, ngram_hits, lang, table_name):
-        """Update n-gram hit count values in this table"""
-        with self._conn:
             for ngram, hits in ngram_hits.items():
-                ngram = ngram.replace("'", "''")
-                sql = (
-                    f"INSERT INTO {table_name} VALUES ('{ngram}', '{lang}', {hits}) "
-                    f"ON CONFLICT (gram, lang) DO UPDATE SET hit = hit + {hits};"
+                ngram = ngram.replace("'", "''")  # escape single quotes
+                conn.execute(
+                    f"""
+                    INSERT INTO {table_name} 
+                      VALUES ('{ngram}', '{lang}', {hits}) 
+                    ON CONFLICT (gram, lang) 
+                      DO UPDATE SET hit = hit + {hits};
+                    """
                 )
-                self._conn.execute(sql)
-            self._conn.execute("PRAGMA shrink_memory;")
+            conn.execute("PRAGMA shrink_memory;")  # reduce memory load
 
-    def _insert_user_stats(self, user_lang_score):
+    def _insert_user_scores(self, user_lang_score: dict) -> None:
         """Insert user language contribution scores into table"""
-        print("Inserting user stats...")
-        with self._conn:
-            self._conn.execute("PRAGMA shrink_memory;")
+
+        print("Inserting users contribution scores")
+        with sqlite3.connect(self._fp) as conn:
             for (user, lang), hit in user_lang_score.items():
-                self._conn.execute(
-                    "INSERT INTO %s VALUES (?,?,?);" % (TABLE_USR_STAT),
+                conn.execute(
+                    "INSERT INTO users_langs VALUES (?,?,?);",
                     (user, lang, hit),
                 )
-            self._conn.execute("PRAGMA shrink_memory;")
+            conn.execute("PRAGMA shrink_memory;")  # reduce memory load
 
     @staticmethod
-    def _print_status(line_number, gram_length, force=False):
+    def _print_status(
+        line_number: int, ngram_size: int, force: bool = False
+    ) -> None:
         """Keep track of n-gram counting progress"""
+
         if line_number % 10000 == 0 or force:
             msg = (
-                f"\rGenerating ngrams of size {gram_length} "
+                f"\rGenerating ngrams of size {ngram_size} "
                 f"(reading CSV file... {line_number} lines)"
             )
             print(msg, end="")
             sys.stdout.flush()
 
     @property
-    def path(self):
+    def path(self) -> Path:
+        """Get the path of the database file"""
 
         return self._fp
 
 
 class TatodetectDB:
+    """The actual database that is used to detect languages
+    on tatoeba.org
+
+    The Tatodetect algorithm is based on the analysis of the
+    key n-grams found in a Tatoeba monolingual corpus.
+
+    This database contains only the key content of the
+    Tatodetect 'raw database'.
+    """
+
     def __init__(self, db_path: Path) -> None:
         """
         Parameters
         ----------
         db_path : Path
-            the location of the sqlite databse
+            the location of the sqlite database
         """
         self._fp = db_path
 
-        self._conn = self._init_db()
-
-    def extract_top_from(self, ngram_counter_db: NgramCounterDB) -> None:
-        """Copy most significant content
-        from an n-gram counter sqlite database
+    def extract_key_content_from(self, raw_db: RawTatodetectDB) -> None:
+        """Import key content from the Tatodetect raw database
 
         Parameters
         ----------
-        ngram_counter_db : NgramCounterDB
-            a database containing all Tatoeba n-grams counts
+        raw_db : RawTatodetectDB
+            a database containing all Tatoeba n-grams counts and user
+            contribution scores
         """
-        # delete older database found at this path
+        # the former Tatodetect database is overwritten
         if self._fp.exists():
-            print(f"Warning: the previous top data will be overwritten")
+            print(f"Deleting former {self._fp.name} database")
             self._fp.unlink()
-            self._conn = self._init_db()
+        # Initialize tables
+        self._init_db()
 
-        c = self._conn.cursor()
+        conn = sqlite3.connect(self._fp)
+        c = conn.cursor()
 
-        # attach top database to enable data transfert
-        c.execute(f"ATTACH DATABASE '{ngram_counter_db.path}' AS counter")
+        # attach raw database to enable data transfert
+        c.execute(f"ATTACH DATABASE '{raw_db.path}' AS raw_db;")
 
         for n in range(MIN_NGRAM_SIZE, MAX_NGRAM_SIZE + 1):
-            print(f"Extracting top {n}-grams from counter database")
+            print(f"Importing key {n}-grams from raw database")
+            # transfer n-grams counts table with extra frequencies
             c.execute(
                 f"""
                 INSERT INTO main.grams{n}
                 SELECT
                   gram,
-                  counter.grams{n}.lang,
+                  raw_db.grams{n}.lang,
                   hit,
-                  CAST(hit AS FLOAT) / CAST(lang_ngram_tots.tot AS FLOAT) AS percent
-                FROM counter.grams{n}
+                  CAST(hit AS FLOAT) / lang_ngram_tots.tot AS percent
+                FROM raw_db.grams{n}
                 INNER JOIN (
                 SELECT
                   lang, 
                   SUM(hit) AS tot
-                FROM counter.grams{n}
+                FROM raw_db.grams{n}
                 GROUP BY lang) AS lang_ngram_tots
-                ON counter.grams{n}.lang = lang_ngram_tots.lang
+                ON raw_db.grams{n}.lang = lang_ngram_tots.lang
                 WHERE percent > (
                 CASE
-                  WHEN counter.grams{n}.lang IN {IDEOGRAM_LANGS}
+                  WHEN raw_db.grams{n}.lang IN {IDEOGRAM_LANGS}
                   THEN {IDEOGRAM_NGRAM_FREQ_LIMIT} ELSE {NGRAM_FREQ_LIMIT}
-                END)
+                END);
                 """
             )
+            c.execute(f"CREATE INDEX gram_grams{n}_idx ON grams{n}(gram);")
 
-        print(f"Extracting top contributors")
+        print(f"Importing key Tatoeba contributors from raw database")
         c.execute(
             f"""
             INSERT INTO main.users_langs
-            SELECT * FROM counter.users_langs
-            WHERE total > {MIN_USER_CONTRIB_IN_LANG}
+              SELECT * FROM raw_db.users_langs
+              WHERE total > {MIN_USER_CONTRIB_IN_LANG};
             """
         )
+        c.execute(
+            """
+            CREATE UNIQUE INDEX lang_user_users_langs_idx 
+              ON users_langs(lang,user);
+            """
+        )
+        c.execute("CREATE INDEX user_users_langs_idx ON users_langs(user);")
 
-        self._conn.commit()
+        conn.commit()
 
-        c.execute("DETACH DATABASE counter")
+        c.execute("DETACH DATABASE raw_db;")
 
         c.close()
 
-    def _init_db(self):
+    def _init_db(self) -> None:
+        """Open tha database connection and initialize the tables"""
 
-        conn = sqlite3.connect(self._fp)
-        with conn:
+        with sqlite3.connect(self._fp) as conn:
             # create a table for each n-gram type counts
             for n in range(MIN_NGRAM_SIZE, MAX_NGRAM_SIZE + 1):
                 conn.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS %s (
+                    f"""
+                    CREATE TABLE IF NOT EXISTS grams{n} (
                     'gram' text not null,
                     'lang'text not null,
                     'hit'  int not null,
@@ -311,21 +336,23 @@ class TatodetectDB:
                     PRIMARY KEY("gram","lang")
                     );
                     """
-                    % (TABLE_NGRAM + str(n))
                 )
             # create a table for storing the sentences counts of users
             conn.execute(
                 """
-                CREATE TABLE IF NOT EXISTS %s (
-                    'user' text not null,
-                    'lang' text not null ,
-                    'total' int not null default 0
+                CREATE TABLE IF NOT EXISTS users_langs (
+                  'user' text not null,
+                  'lang' text not null ,
+                  'total' int not null default 0
                 );
                 """
-                % (TABLE_USR_STAT)
             )
 
-        return conn
+    @property
+    def path(self) -> Path:
+        """Get the path of the database file"""
+
+        return self._fp
 
 
 def get_sentences_with_tag(tags_path: Path, tag_name: str) -> set:
@@ -341,7 +368,7 @@ def get_sentences_with_tag(tags_path: Path, tag_name: str) -> set:
     Returns
     -------
     set
-        the integer ids of the tagged sentences mapping to True
+        the integer ids of the tagged sentences
     """
     tagged = set()
     try:
@@ -356,8 +383,18 @@ def get_sentences_with_tag(tags_path: Path, tag_name: str) -> set:
     return tagged
 
 
-if __name__ == "__main__":
+def get_raw_db_path(db_path: Path) -> Path:
+    """Get the path where the raw database associated with this database
+    will be saved
+    """
+    return db_path.parent.joinpath(f"{db_path.stem}_raw{db_path.suffix}")
 
+
+def main():
+
+    buffer_length = 5000000  # ~700MB process memory at peak
+
+    # manage CLI inputs
     if len(sys.argv) < 3:
         fnames = "sentences_detailed.csv", "ngrams.db", "tags.csv"
         msg = f"Usage: {sys.argv[0]} <{fnames[0]}> <{fnames[1]}> [{fnames[2]}]"
@@ -365,18 +402,26 @@ if __name__ == "__main__":
         sys.exit(1)
 
     sentences_detailed_path = Path(sys.argv[1])
-    database_path = Path(sys.argv[2])
+    tatodetect_db_path = Path(sys.argv[2])
     try:
         tags_path = Path(sys.argv[3])
     except IndexError:
         tags_path = None
 
+    # the sentences tagged with '@change flag' are blacklisted because
+    # they are very likely linked to wrong languages
     sentence_blacklist = get_sentences_with_tag(tags_path, "@change flag")
+    # create a database that store all n-grams counts and users scores in the
+    # same directory as the smaller final database actually used by Tatodetect
+    raw_db_path = get_raw_db_path(tatodetect_db_path)
+    raw_db = RawTatodetectDB(raw_db_path)
+    raw_db.count(sentences_detailed_path, sentence_blacklist, buffer_length)
+    # copy most significant content from the raw database to the actual
+    # Tatodetect database
+    tatodetect_db = TatodetectDB(tatodetect_db_path)
+    tatodetect_db.extract_key_content_from(raw_db)
 
-    ngram_counter_path = database_path.parent.joinpath("ngram_counter.db")
-    ngram_counter_db = NgramCounterDB(ngram_counter_path)
-    ngram_counter_db.count_ngram_hits(
-        sentences_detailed_path, sentence_blacklist, buffer_length=5000000
-    )
-    tatodetect_db = TatodetectDB(database_path)
-    tatodetect_db.extract_top_from(ngram_counter_db)
+
+if __name__ == "__main__":
+
+    main()

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -1,30 +1,29 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-#Tatoeba Project, free collaborative creation of multilingual corpuses project
-#Copyright (C) 2012 Allan SIMON <allan.simon@supinfo.com>
+# Tatoeba Project, free collaborative creation of multilingual corpuses project
+# Copyright (C) 2012 Allan SIMON <allan.simon@supinfo.com>
 #
-#This program is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Affero General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Affero General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
 #
-#You should have received a copy of the GNU Affero General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-#@category Tatodetect
-#@package  Tools
-#@author   Allan SIMON <allan.simon@supinfo.com>
-#@license  Affero General Public License
-#@link     http://tatoeba.org
+# @category Tatodetect
+# @package  Tools
+# @author   Allan SIMON <allan.simon@supinfo.com>
+# @license  Affero General Public License
+# @link     http://tatoeba.org
 #
-
 import codecs
 import os
 import sqlite3
@@ -35,7 +34,7 @@ from collections import defaultdict
 # we put them apart as they are likely to have a lot of different
 # ngrams and by so need to have a lower limit for the ngrams we kept
 # for that languages
-IDEOGRAM_LANGS = frozenset(['wuu','yue','cmn'])
+IDEOGRAM_LANGS = frozenset(["wuu", "yue", "cmn"])
 IDEOGRAM_NGRAM_FREQ_LIMIT = 0.000005
 NGRAM_FREQ_LIMIT = 0.00001
 # number of 1-gram a user must have submitted in one language to
@@ -52,15 +51,19 @@ INSERT_NGRAM = "INSERT INTO %s VALUES (?,?,?,?);"
 INSERT_USR_STAT = "INSERT INTO %s VALUES (?,?,?);"
 
 
-# create the database and all the required tables 
-def generate_db(database):
+def generate_db(database_path):
+    """Create the database and all the required tables
 
-    conn = sqlite3.connect(database)
-    conn.row_factory = sqlite3.Row;
+    Parameters
+    ----------
+    database_path : str
+        the path of the Tatodetect sqlite database
+    """
+    conn = sqlite3.connect(database_path)
+    conn.row_factory = sqlite3.Row
     c = conn.cursor()
 
-    for size in range(2,UP_TO_N_GRAM+1):
-
+    for size in range(2, UP_TO_N_GRAM + 1):
         table = TABLE_NGRAM + str(size)
         c.execute(
             """
@@ -70,9 +73,9 @@ def generate_db(database):
              'hit'  int not null,
              'percent' float not null default 0
             );
-            """ % (table)
-        );
-
+            """
+            % (table)
+        )
     conn.commit()
 
     c.execute(
@@ -82,195 +85,230 @@ def generate_db(database):
             'lang' text not null ,
             'total' int not null default 0
         );
-        """ % (TABLE_USR_STAT)
+        """
+        % (TABLE_USR_STAT)
     )
     conn.commit()
     c.close()
 
-def sentencesWithTag(tagsFile, tagName):
-    tagged = {}
-    with open(tagsFile) as fp:
-        for line in fp:
-            try:
-                cols = line[:-1].split("\t")
-                sentenceId  = cols[0]
-                sentenceTag = cols[1]
-                if sentenceTag == tagName:
-                    tagged[sentenceId] = True
-            except IndexError:
-                pass
 
-    return tagged
+def generate_n_grams(database_path, sentences_path, tags_path):
+    """Count the occurrences of the ngrams in the Tatoeba corpora
 
-def print_status_line(size, lineNumber):
-    print('\rGenerating ngrams of size {} (reading CSV file... {} lines)'.format(size, lineNumber), end='')
-    sys.stdout.flush()
-
-def generate_n_grams(database, sentences_detailed, tags):
-
-    #tableStat = TABLE_STAT + str(size)
-    conn = sqlite3.connect(database)
-    conn.isolation_level="EXCLUSIVE"
-    conn.row_factory = sqlite3.Row;
+    Parameters
+    ----------
+    database_path : str
+        the path of the Tatodetect sqlite database
+    sentences : str
+        the path of the Tatoeba 'sentences_detailed.csv' datafile
+    tags_path : str
+        the path of the Tatoeba tags datafile
+    """
+    conn = sqlite3.connect(database_path)
+    conn.isolation_level = "EXCLUSIVE"
+    conn.row_factory = sqlite3.Row
     c = conn.cursor()
     # some optimization to make it faster
-    c.execute('PRAGMA page_size=627680;')
-    c.execute('pragma default_cache_size=320000;')
-    c.execute('PRAGMA synchronous=OFF;')
-    c.execute('PRAGMA count_changes=OFF;')
-    c.execute('PRAGMA temp_store=MEMORY;')
-    c.execute('PRAGMA journal_mode=MEMORY;')
+    c.execute("PRAGMA page_size=627680;")
+    c.execute("PRAGMA default_cache_size=320000;")
+    c.execute("PRAGMA synchronous=OFF;")
+    c.execute("PRAGMA count_changes=OFF;")
+    c.execute("PRAGMA temp_store=MEMORY;")
+    c.execute("PRAGMA journal_mode=MEMORY;")
 
-    input = codecs.open(
-        sentences_detailed,
-        'r',
-        encoding='utf-8'
-    )
+    input = codecs.open(sentences_path, "r", encoding="utf-8")
 
-    wrongFlags = {}
-    if tags:
-        wrongFlags = sentencesWithTag(tags, '@change flag')
+    wrong_flags = {}
+    if tags_path:
+        wrong_flags = get_sentences_with_tag(tags_path, "@change flag")
 
-    userLangNbrNgram = defaultdict(lambda: 0)
+    user_lang_nbr_ngram = defaultdict(int)
     for size in range(UP_TO_N_GRAM, 1, -1):
-        hyperLangNgram = defaultdict(
-            lambda: defaultdict(lambda: 0)
-        )
-        hyperLangNbrNgram = defaultdict(lambda: 0)
+        hyper_lang_ngram = defaultdict(lambda: defaultdict(int))
+        hyper_lang_nbr_ngram = defaultdict(int)
 
-        lineNumber = 0
+        line_number = 0
         input.seek(0)
         for line in input:
-            if lineNumber % 10000 == 0:
-                print_status_line(size, lineNumber)
+            if line_number % 10000 == 0:
+                print_status_line(size, line_number)
 
-            lineNumber += 1
+            line_number += 1
             try:
-                cols = line[:-1].split("\t")
-                sentenceId = cols[0]
-                lang = cols[1]
-                text = cols[2]
-                user = cols[3]
+                cols = line.rstrip().split("\t")
+                sentence_id, lang, text, user = cols[:4]
             except IndexError:
-                print('Skipped erroneous line {}: {}'.format(lineNumber, line))
+                print(
+                    "Skipped erroneous line {}: {}".format(line_number, line)
+                )
                 continue
 
             # we ignore the sentence with an unset language
-            if lang == '\\N' or lang == '':
+            if lang == "\\N" or lang == "":
                 continue
 
             # we ignore the sentence with wrong flag
-            if sentenceId in wrongFlags:
+            if sentence_id in wrong_flags:
                 continue
 
-            userLangNbrNgram[(user,lang)] += len(text)
-            nbrNgramLine = len(text) - size
-            if nbrNgramLine > 0:
-                hyperLangNbrNgram[lang] += nbrNgramLine
-                for i in range(nbrNgramLine+1):
-                    ngram = text[i:i+size]
-                    hyperLangNgram[lang][ngram] += 1
-        print_status_line(size, lineNumber)
-        print(' done'.format(lineNumber))
+            # update counts
+            user_lang_nbr_ngram[(user, lang)] += len(text)
+            nbr_ngram_line = len(text) - size
+            if nbr_ngram_line > 0:
+                hyper_lang_nbr_ngram[lang] += nbr_ngram_line
+                for i in range(nbr_ngram_line + 1):
+                    ngram = text[i : i + size]
+                    hyper_lang_ngram[lang][ngram] += 1
 
+        print_status_line(size, line_number)
+        print(" done".format(line_number))
 
-        print('Inserting ngrams of size {}...'.format(size))
+        print("Inserting ngrams of size {}...".format(size))
 
         table = TABLE_NGRAM + str(size)
-        
-        for lang, currentLangNgram in hyperLangNgram.items():
-            for ngram,hit in currentLangNgram.items():
-                freq = float(hit) / hyperLangNbrNgram[lang]
+        for lang, currentLangNgram in hyper_lang_ngram.items():
+            for ngram, hit in currentLangNgram.items():
+                freq = float(hit) / hyper_lang_nbr_ngram[lang]
 
                 if lang in IDEOGRAM_LANGS:
                     if freq > IDEOGRAM_NGRAM_FREQ_LIMIT:
                         c.execute(
-                            INSERT_NGRAM % (table),
-                            (ngram,lang,hit,freq)
+                            INSERT_NGRAM % (table), (ngram, lang, hit, freq)
                         )
                 else:
                     if freq > NGRAM_FREQ_LIMIT:
-
                         c.execute(
-                            INSERT_NGRAM % (table),
-                            (ngram,lang,hit,freq)
-                            )
+                            INSERT_NGRAM % (table), (ngram, lang, hit, freq)
+                        )
             conn.commit()
 
-    print('Inserting user stats...')
-    for (user,lang),hit in userLangNbrNgram.items():
+    print("Inserting user stats...")
+    for (user, lang), hit in user_lang_nbr_ngram.items():
         if hit > USR_LANG_LIMIT:
-            c.execute(
-                INSERT_USR_STAT % (TABLE_USR_STAT),
-                (user,lang,hit)
-            )
+            c.execute(INSERT_USR_STAT % (TABLE_USR_STAT), (user, lang, hit))
     conn.commit()
     c.close()
 
-# create indexes on the database to make request faster
-def create_indexes_db(database):
-    conn = sqlite3.connect(database)
-    conn.isolation_level="EXCLUSIVE"
-    conn.row_factory = sqlite3.Row;
+
+def create_indexes_db(database_path):
+    """Add indexes on the database to make request faster
+
+    Parameters
+    ----------
+    database_path : str
+        the path of the Tatodetect sqlite database
+    """
+    conn = sqlite3.connect(database_path)
+    conn.isolation_level = "EXCLUSIVE"
+    conn.row_factory = sqlite3.Row
     c = conn.cursor()
-    c.execute('PRAGMA page_size=627680;')
-    c.execute('pragma default_cache_size=320000;')
-    c.execute('PRAGMA synchronous=OFF;')
-    c.execute('PRAGMA count_changes=OFF;')
-    c.execute('PRAGMA temp_store=MEMORY;')
-    c.execute('PRAGMA journal_mode=MEMORY;')
+    c.execute("PRAGMA page_size=627680;")
+    c.execute("PRAGMA default_cache_size=320000;")
+    c.execute("PRAGMA synchronous=OFF;")
+    c.execute("PRAGMA count_changes=OFF;")
+    c.execute("PRAGMA temp_store=MEMORY;")
+    c.execute("PRAGMA journal_mode=MEMORY;")
 
-
-    for i in range(2,UP_TO_N_GRAM+1):
+    for i in range(2, UP_TO_N_GRAM + 1):
         c.execute(
             """
             CREATE INDEX
                 gram_grams%d_idx
             ON grams%d(gram);
-            """ % (i,i)
+            """
+            % (i, i)
         )
-
     c.execute(
         """
         CREATE UNIQUE INDEX
             lang_user_users_langs_idx
         ON
             %s(lang,user);
-        """ %(TABLE_USR_STAT)
+        """
+        % (TABLE_USR_STAT)
     )
     c.execute(
         """
         CREATE INDEX
            user_%s_idx
         ON %s(user);
-        """ % (TABLE_USR_STAT,TABLE_USR_STAT)
+        """
+        % (TABLE_USR_STAT, TABLE_USR_STAT)
     )
-
-
-
     conn.commit()
     c.close()
 
-if len(sys.argv) < 3:
-    print("Usage: {} <sentences_detailed.csv> <ngrams.db> [tags.csv]".format(sys.argv[0]))
-    sys.exit(1)
 
-sentences_detailed = sys.argv[1]
-database = sys.argv[2]
-try:
-    tags = sys.argv[3]
-except IndexError:
-    tags = None
+def get_sentences_with_tag(tags_path, tag_name):
+    """Fetch ids of all Tatoeba sentences tagged with this tag
 
-# we first delete the old database
-if (os.path.isfile(database)):
-    os.remove(database)
+    Parameters
+    ----------
+    tags_path : str
+        the path of the Tatoeba tags.csv dump file
+    tag_name : str
+        the tag for which tagged sentences are looked for
 
-print("Start generating database...")
-generate_db(database)
+    Returns
+    -------
+    dict
+        the ids of the tagged sentences mapping to True
+    """
+    tagged = set()
+    try:
+        with open(tags_path, "r", encoding="utf-8") as f:
+            for line in f:
+                sentence_id, tag = line.rstrip().split("\t")
+                if tag == tag_name:
+                    tagged.add(sentence_id)
+    except IndexError:
+        pass
 
-print("generating n-grams...")
-generate_n_grams(database, sentences_detailed, tags)
+    return tagged
 
-print("creating indexes...")
-create_indexes_db(database)
+
+def print_status_line(size, line_number):
+    """Print the progress of the ngram counting
+
+    Parameters
+    ----------
+    size : int
+        the size of the ngram (i.e. 3 for 3-grams)
+    line_number : int
+        the index of the processed line in sentences csv file
+    """
+    msg = (
+        f"\rGenerating ngrams of size {size} "
+        f"(reading CSV file... {line_number} lines)"
+    )
+    print(msg, end="")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) < 3:
+        fnames = "sentences_detailed.csv", "ngrams.db", "tags.csv"
+        msg = f"Usage: {sys.argv[0]} <{fnames[0]}> <{fnames[1]}> [{fnames[2]}]"
+        print(msg)
+        sys.exit(1)
+
+    sentences_path = sys.argv[1]
+    database_path = sys.argv[2]
+    try:
+        tags_path = sys.argv[3]
+    except IndexError:
+        tags_path = None
+
+    # we first delete the old database
+    if os.path.isfile(database_path):
+        os.remove(database_path)
+
+    print("Start generating database...")
+    generate_db(database_path)
+
+    print("generating n-grams...")
+    generate_n_grams(database_path, sentences_path, tags_path)
+
+    print("creating indexes...")
+    create_indexes_db(database_path)

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -1,26 +1,3 @@
-# Tatoeba Project, free collaborative creation of multilingual corpuses project
-# Copyright (C) 2012 Allan SIMON <allan.simon@supinfo.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
-# @category Tatodetect
-# @package  Tools
-# @author   Allan SIMON <allan.simon@supinfo.com>
-# @license  Affero General Public License
-# @link     http://tatoeba.org
-#
 import sqlite3
 import sys
 from collections import defaultdict

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sqlite3
 import sys
 from collections import defaultdict

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -151,7 +151,7 @@ class RawTatodetectDB:
                       'gram' text not null,
                       'lang'text not null,
                       'hit'  int not null,
-                    PRIMARY KEY("gram","lang")
+                    UNIQUE("gram","lang")
                     );
                     """
                 )
@@ -328,8 +328,7 @@ class TatodetectDB:
                     'gram' text not null,
                     'lang'text not null,
                     'hit'  int not null,
-                    'percent' float not null default 0,
-                    PRIMARY KEY("gram","lang")
+                    'percent' float not null default 0
                     );
                     """
                 )


### PR DESCRIPTION
The script that generates the Tatodetect sqlite file has been completely overhauled to solve the issue mentioned [here](https://github.com/Tatoeba/tatoeba2/issues/2671).

From now on, the size of the memory allocated to the process does not scale up with the size of the Tatoeba corpus and is capped by default around 700MB. It is possible to further reduce this footprint by decreasing the value of the `buffer_length` parameter in the `generate.py` file. But this is done at the expense of the script execution speed...

In addition to the database that feeds Tatodetect,  we now also keep a larger database that is used to store all the results provided by the script. In the future, this could help us to process only the few sentences that separate two versions of Tatoeba, and thus considerably reduce the resources allocated to the weekly update of the Tatodetect database.

Note that the n-gram frequencies slightly differ from the ones generated by the current version of the script.  This is due to the fact that sentences that contain only one n-gram (i.e. "OK!" is the only 3-gram found in the "OK!" sentence) are no longer discarded.
