### PR TITLE
Reduce memory usage during installation by disabling cppcms test build 

### DIFF
--- a/ansible/tasks/install_tatodetect.yml
+++ b/ansible/tasks/install_tatodetect.yml
@@ -18,6 +18,11 @@
     path: '/tmp/cppcms-1.0.5/CMakeLists.txt'
     regexp: "^(enable_testing\\(\\))$"
     replace: "#\\1"
+- name: Disable building tests for cppcms
+  replace:
+    path: '/tmp/cppcms-1.0.5/CMakeLists.txt'
+    regexp: "^(.*\\$\\{TEST\\}.*)$"
+    replace: "#\\1"
 - name: Generate makefile for cppcms
   command: cmake . chdir=/tmp/cppcms-1.0.5
 - name: Compile cppcms

--- a/ansible/tasks/install_tatodetect.yml
+++ b/ansible/tasks/install_tatodetect.yml
@@ -10,17 +10,17 @@
     state: present
 - name: Fetch cppcms source
   get_url: url=http://downloads.sourceforge.net/project/cppcms/cppcms/1.0.5/cppcms-1.0.5.tar.bz2 dest=/tmp/
-- name: Extract source from the archive
+- name: Extract cppcms source from the archive
   command: tar -jxvf cppcms-1.0.5.tar.bz2 chdir=/tmp/
   when: install_state is failed or force_install == true
-- name: Disable testing
+- name: Disable testing for cppcms
   replace:
     path: '/tmp/cppcms-1.0.5/CMakeLists.txt'
     regexp: "^(enable_testing\\(\\))$"
     replace: "#\\1"
-- name: Generate makefile
+- name: Generate makefile for cppcms
   command: cmake . chdir=/tmp/cppcms-1.0.5
-- name: Compile
+- name: Compile cppcms
   command: make -j2 chdir=/tmp/cppcms-1.0.5
 - name: Install
   command: make install chdir=/tmp/cppcms-1.0.5
@@ -30,9 +30,9 @@
     state: present
 - name: Fetch tatodetect source
   git: repo=https://github.com/Tatoeba/Tatodetect.git dest=/tmp/tatodetect
-- name: Generate makefile
+- name: Generate makefile for tatodetect
   command: cmake . chdir=/tmp/tatodetect
-- name: Compile
+- name: Compile tatodetect
   command: make -j2 chdir=/tmp/tatodetect
 - name: Copy the binary to system-wide location
   command: cp tatodetect /usr/local/bin/tatodetect chdir=/tmp/tatodetect


### PR DESCRIPTION
After taking a closer look at the out-of-memory error in Tatoeba/tatoeba2#2859 , I noticed that the error always happened when compiling one of the tests for cppcms (specifically `xss_test`). Since running the tests is already disabled, building them is completely unnecessary. Commenting out the corresponding lines of cppcms's `CMakeLists.txt` reduces the memory requirements enough for the build to succeed.

(By the way, is there some way to make Ansible present the output of failed commands in a more readable way than the one-line JSON object it produces by default? That was fairly annoying to work with.)